### PR TITLE
docs(ATOM-DOCS-): documentation-weekly-9

### DIFF
--- a/meetings/9th_Weekly/9th_weekly_minute.md
+++ b/meetings/9th_Weekly/9th_weekly_minute.md
@@ -1,0 +1,48 @@
+# ATA DA 9ª REUNIÃO DO GRUPO DE INICIAÇÃO CIENTÍFICA – BRAÇO ROBÓTICO
+
+**Data da Reunião:** 28 de junho de 2025
+
+**Membros Presentes:**
+
+- Eduardo Amaral
+- Enzo Ribas
+- Nicolas Garcia
+- Ricardo Freitas
+
+---
+
+## Pautas Discutidas
+
+1. **Artigos**
+
+   - Apresentação breve de artigo escolhido por Nicolas Garcia.
+   - Discussão breve das bibliotecas YOLO e OpenCV, com foco em visão computacional e detecção de objetos.
+
+2. **Oficina de Robótica**
+
+   - Foi discutida a organização da oficina de robótica, ficando a definir a data e o local por votação entre os membros no grupo de WhatsApp.
+
+3. **Hardware**
+
+   - A impressão 3D das peças do braço robótico foi finalizada, estando todas as peças já impressas.
+   - Foi definido o local dos armários onde serão guardados os componentes do braço robótico: Sala de Metodologias (Prédio I, 2º andar).
+
+## Encaminhamentos
+
+- **Revista Cientifica**
+
+  - Responsável: Enzo Ribas
+  - Prazo: Sem Data Limite
+  - Descrição: Pesquisar revista para submissão do artigo
+
+- **Tasks Software**
+
+  - Responsável(is): Nicolas Garcia e Eduardo Amaral
+  - Prazo: Sem Data Limite
+  - Descrição: Estudar bibliotecas de visão computacional (ex: OpenCV, YOLO, FOMO)
+
+---
+
+## Observações Finais
+
+Durante a 9ª reunião do grupo, foram apresentados e discutidos artigos científicos relacionados à visão computacional, com destaque para as bibliotecas YOLO e OpenCV. Também foi debatida a organização da oficina de robótica, cuja data e local serão definidos posteriormente. A equipe concluiu a impressão 3D das peças do braço robótico e definiu o local de armazenamento dos componentes. Encaminhamentos foram estabelecidos para pesquisa de revistas científicas e aprofundamento em bibliotecas de software, com responsáveis designados para cada tarefa.


### PR DESCRIPTION
Este PR adiciona ao repositório a ata referente à 9ª reunião do grupo de iniciação científica realizada no dia 28 de junho de 2025.

**Principais pontos registrados:**

* Apresentação de artigo e discussão sobre bibliotecas YOLO e OpenCV.
* Planejamento da oficina de robótica (data e local a definir).
* Conclusão da impressão 3D das peças do braço robótico.
* Definição do local de armazenamento dos componentes.
* Encaminhamentos definidos:

  * Pesquisa de revista científica (Enzo Ribas).
  * Estudo de bibliotecas de visão computacional (Nicolas Garcia e Eduardo Amaral).

**Motivação:**

Registrar oficialmente os assuntos discutidos e decisões tomadas durante a reunião, assegurando a continuidade e organização do projeto.


